### PR TITLE
CASMTRIAGE-2805 Fix SP3 image customization

### DIFF
--- a/ansible/roles/ca-cert/tasks/main.yml
+++ b/ansible/roles/ca-cert/tasks/main.yml
@@ -28,6 +28,12 @@
     dest: "{{ ca_cert_dest_dir }}"
     remote_src: yes
 
+- name: Update the certificate
+  command: update-ca-certificates
+  when: >
+    ansible_distribution == "SLES" and
+    ansible_distribution_version != "15.3"
+
 # NOTE: update-ca-certificates distributed in SLES 15 SP3 doesn't work
 # in a chrooted environment. Instead, run the scripts directly.
 - name: Find certificate update scripts
@@ -38,8 +44,15 @@
     patterns:
     - '*.run'
   register: ca_scripts
+  when: >
+    ansible_distribution == "SLES" and
+    ansible_distribution_version == "15.3"
+
 
 - name: Run certificate update scripts
   command: "{{ item.path }}"
   loop: "{{ ca_scripts.files }}"
+  when: >
+    ansible_distribution == "SLES" and
+    ansible_distribution_version == "15.3"
     

--- a/ansible/roles/ca-cert/tasks/main.yml
+++ b/ansible/roles/ca-cert/tasks/main.yml
@@ -28,14 +28,15 @@
     dest: "{{ ca_cert_dest_dir }}"
     remote_src: yes
 
+# NOTE: Only run this in SLES 15 SP2, since the version in SLES 15 SP3
+# doesn't work in a chrooted environment.
 - name: Update the certificate
   command: update-ca-certificates
   when: >
     ansible_distribution == "SLES" and
-    ansible_distribution_version != "15.3"
+    ansible_distribution_version == "15.2"
 
-# NOTE: update-ca-certificates distributed in SLES 15 SP3 doesn't work
-# in a chrooted environment. Instead, run the scripts directly.
+# In SLES 15 SP3, run the certificate update scripts directly
 - name: Find certificate update scripts
   find:
     paths:

--- a/ansible/roles/ca-cert/tasks/main.yml
+++ b/ansible/roles/ca-cert/tasks/main.yml
@@ -28,6 +28,18 @@
     dest: "{{ ca_cert_dest_dir }}"
     remote_src: yes
 
-- name: Update the certificate
-  command: update-ca-certificates
+# NOTE: update-ca-certificates distributed in SLES 15 SP3 doesn't work
+# in a chrooted environment. Instead, run the scripts directly.
+- name: Find certificate update scripts
+  find:
+    paths:
+    - /etc/ca-certificates/update.d
+    - /usr/lib/ca-certificates/update.d
+    patterns:
+    - '*.run'
+  register: ca_scripts
+
+- name: Run certificate update scripts
+  command: "{{ item.path }}"
+  loop: "{{ ca_scripts.files }}"
     


### PR DESCRIPTION
## Summary and Scope

The update-ca-certificates script in SLES 15 SP3 doesn't work in a
chroot environment due to missing /dev. To work around this issue,
directly call the underlying scripts that update the trusted
certificate lists.

## Issues and Related PRs

* Resolves [CASMTRIAGE-2805](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-2805)
* Change will also be needed in COS ansible site.yml

## Testing

### Tested on:

  * `loki`

### Test description:

Manually made changes to ansible on loki and ran image customization.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

May cause issues in the future if the update-ca-certificates script does more than run these other scripts.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

