### PR TITLE
CASMCMS-7971 - update dev.cray.com addresses.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.4.0] - 2022-07-14
 ### Added
+- Migrated over to new DST servers for build artifacts
 - Support for SLES SP4
 
 ### Changed

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -87,7 +87,7 @@ pipeline {
         stage("Build SP2") {
             agent {
                 docker {
-                    image "arti.dev.cray.com/dstbuildenv-docker-master-local/cray-sle15sp2_build_environment:latest"
+                    image "arti.hpc.amslabs.hpecorp.net/dstbuildenv-docker-master-local/cray-sle15sp2_build_environment:latest"
                     reuseNode true
                     // Support docker in docker for clamav scan
                     args "-v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker --group-add 999"
@@ -108,7 +108,7 @@ pipeline {
         stage("Build SP3") {
             agent {
                 docker {
-                    image "arti.dev.cray.com/dstbuildenv-docker-master-local/cray-sle15sp3_build_environment:latest"
+                    image "arti.hpc.amslabs.hpecorp.net/dstbuildenv-docker-master-local/cray-sle15sp3_build_environment:latest"
                     reuseNode true
                     // Support docker in docker for clamav scan
                     args "-v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker --group-add 999"


### PR DESCRIPTION
## Summary and Scope

The 'dev.cray.com' domain is being retired and the servers moved to hpe domains.  This PR removes references to servers on this domain where able, and updates to the new hpe addresses where we still need to reference internal servers.  There are no real code changes - should just be pulling the same packages from different locations.

## Issues and Related PRs
* Resolves [CASMCMS-7971](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7971)

## Testing
### Tested on:
  * `Mug`

### Test description:

The new versions of all services are installed on Mug and are being left in place while Jason does Bos v2 testing to give these a complete workout.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N - left in place for 'soak' testing
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This should be low risk as it is just pulling the same stuff from different server addresses.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [x] Testing is appropriate and complete, if applicable
