### PR TITLE
CASMCMS-8691: Build single noos RPM instead of one per SLE SP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [2.6.1] - 2023-08-10
+### Changed
+- Disabled concurrent Jenkins builds on same branch/commit
+- Added build timeout to avoid hung builds
+
 ## [2.6.0] - 2023-06-22
 ### Added
 - Build SLES SP5 RPM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Disabled concurrent Jenkins builds on same branch/commit
 - Added build timeout to avoid hung builds
+- RPM OS type changed to `noos`.
 
 ## [2.6.0] - 2023-06-22
 ### Added

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -33,6 +33,8 @@ pipeline {
 
     options {
         buildDiscarder(logRotator(numToKeepStr: "10"))
+        disableConcurrentBuilds()
+        timeout(time: 90, unit: 'MINUTES')
         timestamps()
     }
 

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -42,10 +42,6 @@ pipeline {
         NAME = "cf-ca-cert-config-framework"
         IS_STABLE = getBuildIsStable()
         BUILD_METADATA = getRpmRevision(isStable: env.IS_STABLE)
-        PUBLISH_SP2 = "sle-15sp2"
-        PUBLISH_SP3 = "sle-15sp3"
-        PUBLISH_SP4 = "sle-15sp4"
-        PUBLISH_SP5 = "sle-15sp5"
     }
 
     stages {
@@ -65,9 +61,9 @@ pipeline {
 
         stage("runBuildPrep") {
             steps {
-                 withCredentials([usernamePassword(credentialsId: 'artifactory-algol60-readonly', passwordVariable: 'ARTIFACTORY_PASSWORD', usernameVariable: 'ARTIFACTORY_USERNAME')]) {
+                withCredentials([usernamePassword(credentialsId: 'artifactory-algol60-readonly', passwordVariable: 'ARTIFACTORY_PASSWORD', usernameVariable: 'ARTIFACTORY_USERNAME')]) {
                     sh "make runbuildprep"
-                    }
+                }
             }
         }
 
@@ -90,13 +86,11 @@ pipeline {
             }
         }
 
-        stage("Build SP2") {
+        stage("Build RPMs") {
             agent {
                 docker {
-                    image "arti.hpc.amslabs.hpecorp.net/dstbuildenv-docker-master-local/cray-sle15sp2_build_environment:latest"
+                    image "artifactory.algol60.net/csm-docker/stable/csm-docker-sle:latest"
                     reuseNode true
-                    // Support docker in docker for clamav scan
-                    args "-v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker --group-add 999"
                 }
             }
             steps {
@@ -104,73 +98,10 @@ pipeline {
             }
         }
 
-        stage('Publish SP2') {
+        stage('Publish RPMs') {
             steps {
-                publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/RPMS/noarch/*.rpm", os: env.PUBLISH_SP2, arch: "noarch", isStable: env.IS_STABLE)
-                publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: env.PUBLISH_SP2, arch: "src", isStable: env.IS_STABLE)
-            }
-        }
-
-        stage("Build SP3") {
-            agent {
-                docker {
-                    image "arti.hpc.amslabs.hpecorp.net/dstbuildenv-docker-master-local/cray-sle15sp3_build_environment:latest"
-                    reuseNode true
-                    // Support docker in docker for clamav scan
-                    args "-v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker --group-add 999"
-                }
-            }
-            steps {
-                sh "make rpm"
-            }
-        }
-
-        stage('Publish SP3') {
-            steps {
-                publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/RPMS/noarch/*.rpm", os: env.PUBLISH_SP3, arch: "noarch", isStable: env.IS_STABLE)
-                publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: env.PUBLISH_SP3, arch: "src", isStable: env.IS_STABLE)
-            }
-        }
-
-        stage("Build SP4") {
-            agent {
-                docker {
-                    image "arti.hpc.amslabs.hpecorp.net/dstbuildenv-docker-master-local/cray-sle15sp4_build_environment:latest"
-                    reuseNode true
-                    // Support docker in docker for clamav scan
-                    args "-v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker --group-add 999"
-                }
-            }
-            steps {
-                sh "make rpm"
-            }
-        }
-
-        stage('Publish SP4') {
-            steps {
-                publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/RPMS/noarch/*.rpm", os: env.PUBLISH_SP4, arch: "noarch", isStable: env.IS_STABLE)
-                publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: env.PUBLISH_SP4, arch: "src", isStable: env.IS_STABLE)
-            }
-        }
-
-        stage("Build SP5") {
-            agent {
-                docker {
-                    image "arti.hpc.amslabs.hpecorp.net/dstbuildenv-docker-master-local/cray-sle15sp5_build_environment:latest"
-                    reuseNode true
-                    // Support docker in docker for clamav scan
-                    args "-v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker --group-add 999"
-                }
-            }
-            steps {
-                sh "make rpm"
-            }
-        }
-
-        stage('Publish SP5') {
-            steps {
-                publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/RPMS/noarch/*.rpm", os: env.PUBLISH_SP5, arch: "noarch", isStable: env.IS_STABLE)
-                publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: env.PUBLISH_SP5, arch: "src", isStable: env.IS_STABLE)
+                publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/RPMS/noarch/*.rpm", os: "noos", arch: "noarch", isStable: env.IS_STABLE)
+                publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: "noos", arch: "src", isStable: env.IS_STABLE)
             }
         }
     }


### PR DESCRIPTION
## Summary and Scope

As part of the larger effort to reduce building RPMs for every SLE SP, this PR changes the cfs-debugger RPM to be built `noos`.

There are a number of benefits to this, including significantly faster builds and less manifest PR headaches, particularly when new SLE SPs are released.

This PR also includes incidental minor improvements to the build environment and process.

No changes to the code itself.
